### PR TITLE
Several fixes and enhancements of the maintain scripts

### DIFF
--- a/bin/fix-mode
+++ b/bin/fix-mode
@@ -5,5 +5,5 @@ IFS="
 
 cd /home/wwwroot/default/nis
 #sudo chown -hR www-data:imgoper data
-sudo chown -hR root:imgoper data
-echo "for f in \"\$@\"; do [ -d \"\$f\" ] && chmod 775 \"\$f\"; [ -f \"\$f\" ] && chmod 664 \"\$f\"; done" | sudo sh /dev/stdin `find data`
+sudo chown -hR root:imgoper data/
+for f in `find data`; do [ -d "$f" ] && chmod 775 "$f"; [ -f "$f" ] && chmod 664 "$f"; done

--- a/bin/update_md5
+++ b/bin/update_md5
@@ -1,37 +1,53 @@
 #! /usr/bin/php5
 <?php
+$nis_root = dirname(__DIR__);
 umask(02);
-//require_once('../includes/config.php');
-require_once('../includes/image_storage.php');
+require_once($nis_root . '/includes/image_storage.php');
 $path = '';
-function ldir($path,$depth) {
+function ldir($path,$depth,$check) {
 	if(storage_path_end($path)) {
 		$list = storage_list($path,false);
 		$info = storage_files_info($path);
+		$dirpath = storage_extend_path($path);
+		//chmod($dirpath, 0775);
 		foreach($list as $item) {
-			echo str_repeat('    ',$depth)."[..]".$item;
-			if(!isset($info[$item]['md5'])) {
-				$dirpath = storage_extend_path($path);
-				chmod($dirpath, 0775);
+			echo str_repeat('    ',$depth)."[....] ".$item;
+			if($check) {
+				if(!isset($info[$item]['md5'])) {
+					echo "\r".str_repeat('    ',$depth)."[FAIL]\n";
+					continue;
+				}
 				$fullpath = $dirpath . '/'.$item;
-				chmod($fullpath, 0664);
 				$md5 = md5_file($fullpath);
-				storage_set_file_info($path.'/'.$item,'md5',$md5);
+				echo "\r".str_repeat('    ',$depth) .
+					"[" . ($info[$item]['md5'] == $md5 ? " OK " : "FAIL") . "]\n";
+			} else {
+				if(!isset($info[$item]['comment'])) {
+					storage_set_file_info($path.'/'.$item,'comment','');
+				}
+				if(isset($info[$item]['md5'])) {
+					//echo "\r".str_repeat('    ',$depth)."[Skip]".$item."\n";
+					echo "\r".str_repeat('    ',$depth)."[Skip]\n";
+				} else {
+					$fullpath = $dirpath . '/'.$item;
+					chmod($fullpath, 0664);
+					chown($fullpath, 'root');
+					chgrp($fullpath, 'imgoper');
+					$md5 = md5_file($fullpath);
+					storage_set_file_info($path.'/'.$item,'md5',$md5);
+					echo "\r".str_repeat('    ',$depth)."[ OK ]\n";
+				}
 			}
-			if(!isset($info[$item]['comment'])) {
-				storage_set_file_info($path.'/'.$item,'comment','');
-			}
-			echo "\r".str_repeat('    ',$depth)."[OK]".$item."\n";
 		}
 	}else{
 		$list = storage_list($path,false);
 		is_array($list) or $list = array();
 		foreach($list as $item) {
 			echo str_repeat('    ',$depth)."$item/\n";
-			ldir($path.'/'.$item,$depth+1);
+			ldir($path.'/'.$item, $depth+1, $check);
 		}
 	}
 }
-ldir($path,0);
+ldir($path, 0, $argc > 1 && $argv[1] == "--check");
 echo "All work complated.\n";
 ?>


### PR DESCRIPTION
Fix `fix-mode` doesn't works when `data` is a symbolic link.
Use the `__DIR__` constant in PHP 5.3+ to get the current script path in `update_md5`, so running this script doesn't need to `cd` to that directory anymore.
Add an option `--check` to `update_md5` to reverify hashes.